### PR TITLE
fix: change the obsolete expression `ThreadStorage.getStorage().get()…

### DIFF
--- a/autotest-agent/src/jvmMain/kotlin/com/epam/drill/test/agent/GlobalConstants.kt
+++ b/autotest-agent/src/jvmMain/kotlin/com/epam/drill/test/agent/GlobalConstants.kt
@@ -21,7 +21,7 @@ import com.epam.drill.test.agent.session.ThreadStorage
 const val TEST_ID_HEADER = "drill-test-id"
 const val SESSION_ID_HEADER = "drill-session-id"
 
-val TEST_NAME_VALUE_CALC_LINE = "((String)${ThreadStorage::class.qualifiedName}.INSTANCE.getStorage().get())"
+val TEST_NAME_VALUE_CALC_LINE = "((String)${ThreadStorage::class.qualifiedName}.INSTANCE.${ThreadStorage::retrieveTestLaunchId.name}())"
 val TEST_NAME_CALC_LINE = "\"$TEST_ID_HEADER\", $TEST_NAME_VALUE_CALC_LINE"
 val SESSION_ID_VALUE_CALC_LINE = "${ThreadStorage::class.qualifiedName}.INSTANCE.${ThreadStorage::sessionId.name}()"
 val SESSION_ID_CALC_LINE = "\"$SESSION_ID_HEADER\", $SESSION_ID_VALUE_CALC_LINE"


### PR DESCRIPTION
…` to actual `ThreadStorage.retrieveTestLaunchId`

EPMDJ-10885